### PR TITLE
fix: improve Canvas rendering logic for better zoom and pan behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Welcome to the Spotify Song Similarity Analysis and Visualization project! This 
 - Tooltips: Displays song information when hovering over nodes.
 
 ## Getting Started:
+
 ## Prerequisites:
 
 - Node.js
@@ -34,11 +35,13 @@ git clone https://github.com/Stanislavstranger/spotify-similarity-map.git
 ```
 
 ### Navigate to the project directory:
+
 ```
 cd spotify-song-similarity
 ```
 
 ### Install dependencies:
+
 ```
 npm install
 ```
@@ -46,10 +49,13 @@ npm install
 ## Running the Application:
 
 ### Run the data retrieval script:
+
 ```
 npm run dev
 ```
+
 ### Open your browser and navigate to:
+
 ```
  http://localhost:5173
 ```
@@ -78,4 +84,3 @@ If you have any questions or suggestions, feel free to reach out to me at stanis
 ---
 
 🙏 Thank you for using our Spotify Song Similarity Analysis and Visualization tool! Enjoy exploring the world of music with me.
-

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -10,10 +10,8 @@ export const Home: React.FC = () => {
   useEffect(() => {
     const fetchData = async () => {
       const loadedData = await loadData();
-      console.log('Data loaded:', loadedData);
       setData(loadedData);
       const matrix = calculateSimilarityMatrix(loadedData);
-      console.log('Similarity matrix calculated:', matrix);
       setSimilarityMatrix(matrix);
     };
 

--- a/src/shared/ui/components/Canvas/Canvas.tsx
+++ b/src/shared/ui/components/Canvas/Canvas.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect, useState } from 'react';
-import { useCanvas } from './useCanvas';
+import { useCanvas } from './hooks/useCanvas';
 import { Tooltip } from '../Tooltip/Tooltip';
 import { Loader } from '../Loader/Loader';
 
@@ -10,7 +10,7 @@ interface CanvasProps {
 
 export const Canvas: React.FC<CanvasProps> = ({ data, similarityMatrix }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const { drawMap, enableCanvasInteractions, resizeCanvas } =
+  const { drawInitialMap, enableCanvasInteractions, resizeCanvas } =
     useCanvas(canvasRef);
   const [tooltipContent, setTooltipContent] = useState<string | null>(null);
   const [tooltipPosition, setTooltipPosition] = useState<{
@@ -25,7 +25,7 @@ export const Canvas: React.FC<CanvasProps> = ({ data, similarityMatrix }) => {
   useEffect(() => {
     if (canvasRef.current && data.length > 0 && similarityMatrix.length > 0) {
       resizeCanvas();
-      drawMap(data, similarityMatrix);
+      drawInitialMap(data, similarityMatrix);
       enableCanvasInteractions(
         data,
         similarityMatrix,
@@ -36,7 +36,13 @@ export const Canvas: React.FC<CanvasProps> = ({ data, similarityMatrix }) => {
       );
       setLoading(false);
     }
-  }, [data, similarityMatrix, drawMap, enableCanvasInteractions, resizeCanvas]);
+  }, [
+    data,
+    similarityMatrix,
+    drawInitialMap,
+    enableCanvasInteractions,
+    resizeCanvas,
+  ]);
 
   const handlePlaybackToggle = () => {
     setAllowPlayback(!allowPlayback);

--- a/src/shared/ui/components/Canvas/hooks/useCanvas.ts
+++ b/src/shared/ui/components/Canvas/hooks/useCanvas.ts
@@ -1,6 +1,11 @@
 import { useCallback, useRef } from 'react';
-import { getTrackPreviewUrl, searchTrack } from '../../../api/spotify/api';
-import { kmeans } from 'ml-kmeans';
+import { handleWheel, handleMouseMove } from '../model/canvasInteractions';
+import {
+  drawMap,
+  getRecommendations,
+  initializeNodes,
+} from '../model/canvasDrawing';
+import { getTrackPreviewUrl, searchTrack } from '../../../../api/spotify/api';
 
 export const useCanvas = (canvasRef: React.RefObject<HTMLCanvasElement>) => {
   const transform = useRef({ x: 0, y: 0, scale: 1 });
@@ -8,6 +13,7 @@ export const useCanvas = (canvasRef: React.RefObject<HTMLCanvasElement>) => {
   const isDragging = useRef(false);
   const startX = useRef(0);
   const startY = useRef(0);
+  const initialPositions = useRef<any[]>([]);
 
   const resizeCanvas = useCallback(() => {
     const canvas = canvasRef.current;
@@ -16,126 +22,6 @@ export const useCanvas = (canvasRef: React.RefObject<HTMLCanvasElement>) => {
       canvas.height = window.innerHeight;
     }
   }, [canvasRef]);
-
-  const drawNode = (
-    ctx: CanvasRenderingContext2D,
-    x: number,
-    y: number,
-    size: number,
-    color: string
-  ) => {
-    ctx.fillStyle = color;
-    ctx.beginPath();
-    ctx.arc(x, y, size, 0, Math.PI * 2);
-    ctx.closePath();
-    ctx.fill();
-  };
-
-  const drawLine = (
-    ctx: CanvasRenderingContext2D,
-    x1: number,
-    y1: number,
-    x2: number,
-    y2: number,
-    color: string
-  ) => {
-    ctx.strokeStyle = color;
-    ctx.beginPath();
-    ctx.moveTo(x1, y1);
-    ctx.lineTo(x2, y2);
-    ctx.stroke();
-  };
-
-  const getRecommendations = (
-    index: number,
-    similarityMatrix: number[][],
-    data: any[],
-    numRecommendations: number = 5
-  ) => {
-    const similarities = similarityMatrix[index];
-    const recommendations = similarities
-      .map((similarity, i) => ({ index: i, similarity }))
-      .sort((a, b) => b.similarity - a.similarity)
-      .slice(1, numRecommendations + 1)
-      .map((rec) => data[rec.index]);
-    return recommendations;
-  };
-
-  const drawMap = useCallback(
-    async (
-      data: any[],
-      similarityMatrix: number[][],
-      highlightedNodeIndex: number | null = null
-    ) => {
-      const canvas = canvasRef.current;
-      if (!canvas) return;
-
-      const ctx = canvas.getContext('2d');
-      if (!ctx) return;
-
-      const width = canvas.width;
-      const height = canvas.height;
-      const maxNodes = data.length;
-
-      const featureVectors = data
-        .slice(0, maxNodes)
-        .map((song) => [song['Track Score'], song['Spotify Streams']]);
-      const k = 5;
-      const options = {
-        maxIterations: 100,
-        tolerance: 1e-4,
-        distanceFunction: (a: number[], b: number[]) => {
-          return Math.sqrt(a.reduce((sum, ai, i) => sum + (ai - b[i]) ** 2, 0));
-        },
-      };
-      const result = kmeans(featureVectors, k, options);
-
-      nodes.current = data.slice(0, maxNodes).map((song, i) => ({
-        x: Math.random() * width,
-        y: Math.random() * height,
-        size: Math.sqrt(song['Track Score']) * 2,
-        song: song,
-        index: i,
-        cluster: result.clusters[i],
-      }));
-
-      const clusterColors = ['red', 'green', 'blue', 'yellow', 'purple'];
-
-      ctx.clearRect(0, 0, width, height);
-
-      ctx.save();
-      ctx.translate(transform.current.x, transform.current.y);
-      ctx.scale(transform.current.scale, transform.current.scale);
-
-      nodes.current.forEach((node) => {
-        drawNode(ctx, node.x, node.y, node.size, clusterColors[node.cluster]);
-      });
-
-      if (highlightedNodeIndex !== null) {
-        const highlightedNode = nodes.current[highlightedNodeIndex];
-        const connections = similarityMatrix[highlightedNodeIndex]
-          .map((similarity, index) => ({ index, similarity }))
-          .sort((a, b) => b.similarity - a.similarity)
-          .slice(1, 11);
-
-        connections.forEach((connection) => {
-          const targetNode = nodes.current[connection.index];
-          drawLine(
-            ctx,
-            highlightedNode.x,
-            highlightedNode.y,
-            targetNode.x,
-            targetNode.y,
-            'gray'
-          );
-          drawNode(ctx, targetNode.x, targetNode.y, targetNode.size, 'red');
-        });
-      }
-
-      ctx.restore();
-    },
-    [canvasRef]
-  );
 
   const enableCanvasInteractions = useCallback(
     (
@@ -152,28 +38,29 @@ export const useCanvas = (canvasRef: React.RefObject<HTMLCanvasElement>) => {
       const ctx = canvas.getContext('2d');
       if (!ctx) return;
 
-      const onWheel = (event: WheelEvent) => {
-        event.preventDefault();
-        const { offsetX, offsetY, deltaY } = event;
-        const zoom = Math.exp(-deltaY / 100);
+      const drawMapCallback = () =>
+        drawMap(
+          ctx,
+          nodes.current,
+          similarityMatrix,
+          transform.current,
+          null,
+          initialPositions.current
+        );
 
-        ctx.translate(offsetX, offsetY);
-        ctx.scale(zoom, zoom);
-        ctx.translate(-offsetX, -offsetY);
-
-        transform.current.x = ctx.getTransform().e;
-        transform.current.y = ctx.getTransform().f;
-        transform.current.scale *= zoom;
-
-        window.requestAnimationFrame(() => drawMap(data, similarityMatrix));
-      };
+      const onWheel = (event: WheelEvent) =>
+        handleWheel(event, canvas, transform.current, drawMapCallback);
 
       const onMouseMove = async (event: MouseEvent) => {
-        if (isDragging.current) {
-          transform.current.x = event.offsetX - startX.current;
-          transform.current.y = event.offsetY - startY.current;
-          window.requestAnimationFrame(() => drawMap(data, similarityMatrix));
-        }
+        handleMouseMove(
+          event,
+          isDragging,
+          transform.current,
+          startX,
+          startY,
+          canvas,
+          drawMapCallback
+        );
 
         const rect = canvas.getBoundingClientRect();
         const x =
@@ -263,16 +150,21 @@ export const useCanvas = (canvasRef: React.RefObject<HTMLCanvasElement>) => {
 
         if (clickedNodeIndex !== -1) {
           window.requestAnimationFrame(() =>
-            drawMap(data, similarityMatrix, clickedNodeIndex)
+            drawMap(
+              ctx,
+              nodes.current,
+              similarityMatrix,
+              transform.current,
+              clickedNodeIndex,
+              initialPositions.current
+            )
           );
-        } else {
-          window.requestAnimationFrame(() => drawMap(data, similarityMatrix));
         }
       };
 
       const handleResize = () => {
         resizeCanvas();
-        window.requestAnimationFrame(() => drawMap(data, similarityMatrix));
+        window.requestAnimationFrame(drawMapCallback);
       };
 
       canvas.addEventListener('wheel', onWheel);
@@ -293,8 +185,38 @@ export const useCanvas = (canvasRef: React.RefObject<HTMLCanvasElement>) => {
         window.removeEventListener('resize', handleResize);
       };
     },
-    [canvasRef, drawMap, resizeCanvas]
+    [canvasRef, resizeCanvas]
   );
 
-  return { drawMap, enableCanvasInteractions, resizeCanvas };
+  const drawInitialMap = useCallback(
+    (data: any[], similarityMatrix: number[][]) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+
+      const width = canvas.width;
+      const height = canvas.height;
+
+      nodes.current = initializeNodes(data, width, height);
+      initialPositions.current = nodes.current.map((node) => ({
+        x: node.x,
+        y: node.y,
+        color: node.color,
+      }));
+
+      drawMap(
+        ctx,
+        nodes.current,
+        similarityMatrix,
+        transform.current,
+        null,
+        initialPositions.current
+      );
+    },
+    [canvasRef]
+  );
+
+  return { drawInitialMap, enableCanvasInteractions, resizeCanvas };
 };

--- a/src/shared/ui/components/Canvas/model/canvasDrawing.ts
+++ b/src/shared/ui/components/Canvas/model/canvasDrawing.ts
@@ -1,0 +1,128 @@
+import { kmeans } from 'ml-kmeans';
+
+export const drawNode = (
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  size: number,
+  color: string
+) => {
+  ctx.fillStyle = color;
+  ctx.beginPath();
+  ctx.arc(x, y, size, 0, Math.PI * 2);
+  ctx.closePath();
+  ctx.fill();
+};
+
+export const drawLine = (
+  ctx: CanvasRenderingContext2D,
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+  color: string
+) => {
+  ctx.strokeStyle = color;
+  ctx.beginPath();
+  ctx.moveTo(x1, y1);
+  ctx.lineTo(x2, y2);
+  ctx.stroke();
+};
+
+export const getRecommendations = (
+  index: number,
+  similarityMatrix: number[][],
+  data: any[],
+  numRecommendations: number = 5
+) => {
+  const similarities = similarityMatrix[index];
+  const recommendations = similarities
+    .map((similarity, i) => ({ index: i, similarity }))
+    .sort((a, b) => b.similarity - a.similarity)
+    .slice(1, numRecommendations + 1)
+    .map((rec) => data[rec.index]);
+  return recommendations;
+};
+
+export const drawMap = (
+  ctx: CanvasRenderingContext2D,
+  nodes: any[],
+  similarityMatrix: number[][],
+  transform: { x: number; y: number; scale: number },
+  highlightedNodeIndex: number | null,
+  initialPositions: any[]
+) => {
+  const width = ctx.canvas.width;
+  const height = ctx.canvas.height;
+
+  ctx.clearRect(0, 0, width, height);
+
+  ctx.save();
+  ctx.translate(transform.x, transform.y);
+  ctx.scale(transform.scale, transform.scale);
+
+  nodes.forEach((node, i) => {
+    drawNode(
+      ctx,
+      initialPositions[i].x,
+      initialPositions[i].y,
+      node.size,
+      initialPositions[i].color
+    );
+  });
+
+  if (highlightedNodeIndex !== null) {
+    const highlightedNode = nodes[highlightedNodeIndex];
+    const connections = similarityMatrix[highlightedNodeIndex]
+      .map((similarity, index) => ({ index, similarity }))
+      .sort((a, b) => b.similarity - a.similarity)
+      .slice(1, 11);
+
+    connections.forEach((connection) => {
+      const targetNode = nodes[connection.index];
+      drawLine(
+        ctx,
+        initialPositions[highlightedNode.index].x,
+        initialPositions[highlightedNode.index].y,
+        initialPositions[targetNode.index].x,
+        initialPositions[targetNode.index].y,
+        'gray'
+      );
+      drawNode(
+        ctx,
+        initialPositions[targetNode.index].x,
+        initialPositions[targetNode.index].y,
+        targetNode.size,
+        'red'
+      );
+    });
+  }
+
+  ctx.restore();
+};
+
+export const initializeNodes = (data: any[], width: number, height: number) => {
+  const featureVectors = data.map((song) => [
+    song['Track Score'],
+    song['Spotify Streams'],
+  ]);
+  const k = 5;
+  const options = {
+    maxIterations: 100,
+    tolerance: 1e-4,
+    distanceFunction: (a: number[], b: number[]) => {
+      return Math.sqrt(a.reduce((sum, ai, i) => sum + (ai - b[i]) ** 2, 0));
+    },
+  };
+  const result = kmeans(featureVectors, k, options);
+
+  return data.map((song, i) => ({
+    x: Math.random() * width,
+    y: Math.random() * height,
+    size: Math.sqrt(song['Track Score']) * 2,
+    song: song,
+    index: i,
+    cluster: result.clusters[i],
+    color: ['red', 'green', 'blue', 'yellow', 'purple'][result.clusters[i]],
+  }));
+};

--- a/src/shared/ui/components/Canvas/model/canvasInteractions.ts
+++ b/src/shared/ui/components/Canvas/model/canvasInteractions.ts
@@ -1,0 +1,56 @@
+export const handleWheel = (
+  event: WheelEvent,
+  canvas: HTMLCanvasElement,
+  transform: { x: number; y: number; scale: number },
+  drawMapCallback: () => void
+) => {
+  event.preventDefault();
+  const { offsetX, offsetY, deltaY } = event;
+  const zoom = Math.exp(-deltaY / 2000);
+
+  const minScale = Math.min(window.innerWidth / canvas.width, 1);
+  const newScale = transform.scale * zoom;
+  if (newScale < minScale) return;
+
+  const rect = canvas.getBoundingClientRect();
+  const cx = (offsetX - rect.left - transform.x) / transform.scale;
+  const cy = (offsetY - rect.top - transform.y) / transform.scale;
+
+  const newTransformX = transform.x - cx * (newScale - transform.scale);
+  const newTransformY = transform.y - cy * (newScale - transform.scale);
+
+  const minX = window.innerWidth - canvas.width * newScale;
+  const minY = window.innerHeight - canvas.height * newScale;
+
+  transform.x = Math.max(minX, Math.min(newTransformX, 0));
+  transform.y = Math.max(minY, Math.min(newTransformY, 0));
+  transform.scale = newScale;
+
+  window.requestAnimationFrame(drawMapCallback);
+};
+
+export const handleMouseMove = (
+  event: MouseEvent,
+  isDragging: React.MutableRefObject<boolean>,
+  transform: { x: number; y: number; scale: number },
+  startX: React.MutableRefObject<number>,
+  startY: React.MutableRefObject<number>,
+  canvas: HTMLCanvasElement,
+  drawMapCallback: () => void
+) => {
+  if (isDragging.current) {
+    let newX = event.offsetX - startX.current;
+    let newY = event.offsetY - startY.current;
+
+    const minX = window.innerWidth - canvas.width * transform.scale;
+    const minY = window.innerHeight - canvas.height * transform.scale;
+
+    newX = Math.max(minX, Math.min(newX, 0));
+    newY = Math.max(minY, Math.min(newY, 0));
+
+    transform.x = newX;
+    transform.y = newY;
+
+    window.requestAnimationFrame(drawMapCallback);
+  }
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,4 +10,3 @@ export default defineConfig(({ mode }) => {
     base: env.VITE_BASE_URL,
   };
 });
-


### PR DESCRIPTION
## Improve Canvas rendering logic for better zoom and pan behavior:
### Оптимизация рендеринга нод:
Проблема: Ноды перерисовывались и меняли цвет при каждом зуме или панорамировании, что приводило к мерцаниям и ухудшению производительности.
- [x] Вынес инициализацию начальных позиций и цветов нод в отдельный блок, чтобы они сохранялись между кадрами.
### Центрирование зума вокруг курсора:
Проблема: При масштабировании Canvas масштабировался вокруг верхнего левого угла, что приводило к неудобствам при работе с Canvas.
  - [x] Изменил логику масштабирования так, чтобы масштабирование происходило вокруг курсора мыши.
### Ограничение перетаскивания Canvas:
Проблема: При перетаскивании Canvas можно было увести его за пределы экрана, что приводило к появлению пустых областей. 
- [x] Добавил ограничение, чтобы Canvas оставался в пределах видимой области экрана при перетаскивании.
### Дополнительные улучшения:
- [x] Отрефакторил существующий код, разделив его на несколько частей, сделав более читаемым и поддерживаемым.